### PR TITLE
Feature/api key cache

### DIFF
--- a/logs/app.log
+++ b/logs/app.log
@@ -65,3 +65,54 @@
 2025-12-03 16:39:25,368 INFO api.utils: user:profile:5
 2025-12-03 16:39:25,368 INFO api.utils: Cache hit for user:identifier:vivan@gmail.com
 2025-12-03 16:39:25,368 INFO api.routers.auth: Cache HIT: User:vivan@gmail.com found in the cache
+2025-12-03 23:29:33,170 INFO api.utils: None
+2025-12-03 23:29:33,171 INFO api.utils: Cache miss for user:identifier:vivan@gmail.com
+2025-12-03 23:29:33,171 INFO api.routers.auth: Cache MISS: User:vivan@gmail.com not found in cache
+2025-12-03 23:29:33,399 INFO api.utils: Cached user data for user_id: 5
+2025-12-03 23:30:12,648 INFO api.utils: Cache hit for user:profile:5
+2025-12-03 23:30:12,648 INFO api.oauth2: Cache HIT: User data found for user_id: 5
+2025-12-03 23:32:53,309 INFO api.utils: Cache hit for user:profile:5
+2025-12-03 23:32:53,310 INFO api.oauth2: Cache HIT: User data found for user_id: 5
+2025-12-03 23:37:12,721 INFO api.utils: Cache hit for user:profile:5
+2025-12-03 23:37:12,721 INFO api.oauth2: Cache HIT: User data found for user_id: 5
+2025-12-03 23:39:33,825 INFO api.utils: Cache hit for user:profile:5
+2025-12-03 23:39:33,825 INFO api.oauth2: Cache HIT: User data found for user_id: 5
+2025-12-03 23:44:36,322 INFO api.utils: Cache hit for user:profile:5
+2025-12-03 23:44:36,322 INFO api.oauth2: Cache HIT: User data found for user_id: 5
+2025-12-03 23:46:02,249 INFO api.utils: Cache hit for user:profile:5
+2025-12-03 23:46:02,249 INFO api.oauth2: Cache HIT: User data found for user_id: 5
+2025-12-03 23:49:00,705 INFO api.utils: Cache hit for user:profile:5
+2025-12-03 23:49:00,705 INFO api.oauth2: Cache HIT: User data found for user_id: 5
+2025-12-03 23:51:15,617 INFO api.utils: Cache hit for user:profile:5
+2025-12-03 23:51:15,617 INFO api.oauth2: Cache HIT: User data found for user_id: 5
+2025-12-03 23:53:03,736 INFO api.utils: Cache MISS for user:profile:api_key:tf_BRL_sEq1WaMQZifmai6z_Qp_9U4sU41SXmyUiJdcZwM
+2025-12-03 23:53:59,192 INFO api.utils: Cache MISS for user:profile:api_key:tf_BRL_sEq1WaMQZifmai6z_Qp_9U4sU41SXmyUiJdcZwM
+2025-12-03 23:57:49,921 INFO api.utils: Cache HIT for user:profile:api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d
+2025-12-03 23:58:20,460 INFO api.utils: Cache HIT for user:profile:api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d
+2025-12-03 23:58:21,315 INFO api.utils: Cache HIT for user:profile:api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d
+2025-12-04 00:01:15,565 INFO api.utils: Cache HIT for user:profile:api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d
+2025-12-04 00:01:15,565 INFO api.oauth2: Cache HIT: The api_key:tf_BRL_sEq1WaMQZifmai6z_Qp_9U4sU41SXmyUiJdcZwM found
+2025-12-04 00:07:13,201 INFO api.oauth2: Cache MISS the api_key: e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d not found
+2025-12-04 00:07:17,188 INFO api.utils: Cache HIT for user:profile:api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d
+2025-12-04 00:07:17,189 INFO api.oauth2: Cache HIT: The api_key:tf_BRL_sEq1WaMQZifmai6z_Qp_9U4sU41SXmyUiJdcZwM found
+2025-12-04 00:07:23,483 INFO api.utils: Cache HIT for user:profile:api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d
+2025-12-04 00:07:23,483 INFO api.oauth2: Cache HIT: The api_key:tf_BRL_sEq1WaMQZifmai6z_Qp_9U4sU41SXmyUiJdcZwM found
+2025-12-04 00:07:24,265 INFO api.oauth2: Cache MISS the api_key: e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d not found
+2025-12-04 00:08:34,200 INFO api.utils: Cache HIT for user:profile:api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d
+2025-12-04 00:08:34,200 INFO api.oauth2: Cache HIT: The api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d found
+2025-12-04 00:12:44,764 INFO api.utils: None
+2025-12-04 00:12:44,764 INFO api.utils: Cache miss for kenny@gmail.com
+2025-12-04 00:12:44,765 INFO api.utils: None
+2025-12-04 00:12:44,765 INFO api.utils: Cache miss for kenny_shah
+2025-12-04 00:12:44,765 INFO api.routers.user: Cache MISS: No user data found for kenny@gmail.com or kenny_shah
+2025-12-04 00:12:44,977 INFO api.routers.user: Caching user data for user_id: 6
+2025-12-04 00:12:44,978 INFO api.utils: Cached user data for user_id: 6
+2025-12-04 00:13:07,176 INFO api.utils: user:profile:6
+2025-12-04 00:13:07,176 INFO api.utils: Cache hit for user:identifier:kenny@gmail.com
+2025-12-04 00:13:07,176 INFO api.routers.auth: Cache HIT: User:kenny@gmail.com found in the cache
+2025-12-04 00:14:04,851 INFO api.utils: Cache HIT for user:profile:api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d
+2025-12-04 00:14:04,851 INFO api.oauth2: Cache HIT: The api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d found
+2025-12-04 00:14:55,828 INFO api.utils: Cache hit for user:profile:6
+2025-12-04 00:14:55,828 INFO api.oauth2: Cache HIT: User data found for user_id: 6
+2025-12-04 00:15:20,448 INFO api.utils: Cache HIT for user:profile:api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d
+2025-12-04 00:15:20,448 INFO api.oauth2: Cache HIT: The api_key:e31d4eca4bb2e522db3bf754738937e02a4efecd6c54eca6804251d5e817d28d found


### PR DESCRIPTION
## 🚀 Summary
This PR implements a **Read-Through Caching strategy** for API Key authentication. It significantly reduces database load by caching validated API keys in Redis, avoiding expensive database JOIN operations on every request.

## 🛠️ Changes
- **Modified `api/oauth2.py`**: Updated `get_user_from_api_key` to check Redis before querying PostgreSQL.
- **Cache Logic**: 
  - **Key**: `apikey:cache:{hashed_key}`
  - **Value**: `owner_id`
  - **TTL**: 5 minutes (300s)
- **Fallback**: If the cache misses, it falls back to the DB query and populates the cache for subsequent requests.
- **Safety**: Added logic to handle edge cases where a key is cached but the user has been deleted.

## 🎯 Motivation
API Key authentication happens on every request. Previously, this required a JOIN query between `api_keys` and `users` tables. By caching the result, we reduce latency and database IOPS for high-traffic endpoints.

## 🧪 How to Test
1. **Generate an API Key** via `POST /api-keys`.
2. **Make a request** using that key (e.g., `GET /tasks`).
   - *First Request:* Should hit the DB (Cache Miss).
   - *Subsequent Requests:* Should hit Redis (Cache Hit).
3. **Verify in Redis:** Run `redis-cli keys "apikey:cache:*"` to see the cached entry.